### PR TITLE
fix page still shows up after unpublish

### DIFF
--- a/djangocms_rest_view/views.py
+++ b/djangocms_rest_view/views.py
@@ -23,7 +23,7 @@ class PageViewSet(viewsets.ReadOnlyModelViewSet):
         if use_draft(self.request):
             return Page.objects.drafts().on_site(site=site).distinct()
         else:
-            return Page.objects.public().on_site(site=site).distinct()
+            return Page.objects.public().published().on_site(site=site).distinct()
 
     def get_placeholder(self, obj):
         slot = self.kwargs['placeholder']


### PR DESCRIPTION
A page being public does not seem to be exactly the same as a page being published.

See how it is done in [cms/models/pagemodel.py](https://github.com/divio/django-cms/blob/release/3.4.x/cms/models/pagemodel.py#L1311):
```python
    def get_object_queryset(self):
        qs = self.__class__.objects
        return (self.publisher_is_draft and qs.drafts() or qs.public().published())
```
When not draft, it takes `.public()`**`.published()`**.